### PR TITLE
Edge cases

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -57,7 +57,7 @@ class Cart
   end
 
   def discount_applies
-    @contents.any? do |item_id|
+    @contents.any? do |item_id, quantity|
       has_discount(Item.find_by(id: item_id))
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,7 @@ merchant_3 = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.',
 #discounts
 off_5 = Discount.create(percentage_discount: 5, item_quantity: 5, merchant_id: merchant_3.id)
 
-off_10 = Discount.create(percentage_discount: 10, item_quantity: 10, merchant_id: merchant_3.id)
+off_10 = Discount.create(percentage_discount: 15, item_quantity: 10, merchant_id: merchant_3.id)
 
 #paper_shop_items
 paper = merchant_1.items.create(name: "Lined Paper", description: "Great for writing on!", price: 20, image: "https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png", inventory: 35)


### PR DESCRIPTION
Add test for edge case for items not linked to a merchant with a discount do not trigger discount apply even if the item quantity is correct. 

Fix hash access mistake in discount applies model method.

Test in development ✅

100 % RSpec coverage.